### PR TITLE
fix: Use processed image for child photo upload

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -199,24 +199,38 @@ function CreateCalendarContent() {
     updateFormField('stickerQuantities', updatedQuantities)
   }
 
-  const handlePhotoUpload = (e: ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0]
-    if (!file) return
+  const handlePhotoUpload = (e: ChangeEvent<HTMLInputElement> | { target: { files: [string] } }) => {
+    // Handle case where we're passed a processed image directly as a string
+    if (typeof e.target.files?.[0] === 'string') {
+      const processedImageUrl = e.target.files[0];
+      setChildPhoto(processedImageUrl);
 
-    const reader = new FileReader()
+      // Set default quantity for child photo
+      updateFormField('stickerQuantities', {
+        ...formData.stickerQuantities,
+        childPhoto: 1
+      });
+      return;
+    }
+
+    // Handle normal file upload case
+    const file = e.target.files?.[0] as File;
+    if (!file) return;
+
+    const reader = new FileReader();
     reader.onload = (event) => {
       if (event.target?.result) {
-        setChildPhoto(event.target.result as string)
+        setChildPhoto(event.target.result as string);
 
         // Set default quantity for child photo
         updateFormField('stickerQuantities', {
           ...formData.stickerQuantities,
           childPhoto: 1
-        })
+        });
       }
-    }
-    reader.readAsDataURL(file)
-  }
+    };
+    reader.readAsDataURL(file);
+  };
 
   const handleBackgroundImageUpload = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -9,6 +9,7 @@ import {
   Activity,
   PreviewMode
 } from './types'
+import { ProcessedImageEvent } from '@/components/create-form/types'
 
 // Import the extracted components
 import { getThemeClasses } from '@/components/calendar/types'
@@ -199,38 +200,41 @@ function CreateCalendarContent() {
     updateFormField('stickerQuantities', updatedQuantities)
   }
 
-  const handlePhotoUpload = (e: ChangeEvent<HTMLInputElement> | { target: { files: [string] } }) => {
-    // Handle case where we're passed a processed image directly as a string
-    if (typeof e.target.files?.[0] === 'string') {
-      const processedImageUrl = e.target.files[0];
-      setChildPhoto(processedImageUrl);
-
-      // Set default quantity for child photo
-      updateFormField('stickerQuantities', {
-        ...formData.stickerQuantities,
-        childPhoto: 1
-      });
-      return;
-    }
-
-    // Handle normal file upload case
-    const file = e.target.files?.[0] as File;
-    if (!file) return;
-
-    const reader = new FileReader();
-    reader.onload = (event) => {
-      if (event.target?.result) {
-        setChildPhoto(event.target.result as string);
+  const handlePhotoUpload = (e: ChangeEvent<HTMLInputElement> | ProcessedImageEvent) => {
+    // If we received a processed image event
+    if ('files' in e.target && Array.isArray(e.target.files) && e.target.files.length > 0) {
+      const processedImageUrl = e.target.files[0]
+      if (typeof processedImageUrl === 'string') {
+        setChildPhoto(processedImageUrl)
 
         // Set default quantity for child photo
         updateFormField('stickerQuantities', {
           ...formData.stickerQuantities,
           childPhoto: 1
-        });
+        })
+        return
       }
-    };
-    reader.readAsDataURL(file);
-  };
+    }
+
+    // Handle standard file upload case - we know it's a ChangeEvent<HTMLInputElement> at this point
+    const fileInput = e as ChangeEvent<HTMLInputElement>
+    const file = fileInput.target.files?.[0]
+    if (!file) return
+
+    const reader = new FileReader()
+    reader.onload = (event) => {
+      if (event.target?.result) {
+        setChildPhoto(event.target.result as string)
+
+        // Set default quantity for child photo
+        updateFormField('stickerQuantities', {
+          ...formData.stickerQuantities,
+          childPhoto: 1
+        })
+      }
+    }
+    reader.readAsDataURL(file)
+  }
 
   const handleBackgroundImageUpload = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]

--- a/src/components/create-form/Step2.tsx
+++ b/src/components/create-form/Step2.tsx
@@ -8,6 +8,13 @@ import Image from 'next/image'
 import { Button, IconButton } from '@/components/ui/Button'
 import useImageUpload from '@/lib/hooks/useImageUpload'
 
+// Type for our synthetic event with processed image
+interface ProcessedImageEvent {
+  target: {
+    files: [string] // Array with exactly one string (the processed image URL)
+  }
+}
+
 function Step2({
   formData,
   childPhoto,
@@ -65,7 +72,7 @@ function Step2({
         target: {
           files: [processedImageUrl]
         }
-      } as any)
+      } as ProcessedImageEvent)
     }
   }, [childPhotoUpload, handlePhotoUpload])
 

--- a/src/components/create-form/Step2.tsx
+++ b/src/components/create-form/Step2.tsx
@@ -54,12 +54,19 @@ function Step2({
     const file = e.target.files?.[0]
     if (!file) return
 
-    // First pass the original event to the parent handler
-    handlePhotoUpload(e)
+    // Process the image for optimization
+    const processedImageUrl = await childPhotoUpload.upload(file)
 
-    // Then process the image for optimization and analytics only
-    // We don't need to use the result since the parent already has the image
-    await childPhotoUpload.upload(file)
+    // If processing was successful, pass the processed image directly to the parent
+    if (processedImageUrl) {
+      // Pass the processed image URL directly to the parent's handlePhotoUpload
+      // The parent function has been modified to handle both File objects and direct data URLs
+      handlePhotoUpload({
+        target: {
+          files: [processedImageUrl]
+        }
+      } as any)
+    }
   }, [childPhotoUpload, handlePhotoUpload])
 
   // Handler for custom image upload

--- a/src/components/create-form/types.ts
+++ b/src/components/create-form/types.ts
@@ -4,6 +4,13 @@ import { getThemeClasses } from '@/components/calendar/types'
 // Define ThemeClasses type based on the return type of getThemeClasses
 export type ThemeClasses = ReturnType<typeof getThemeClasses>
 
+// Type for events with processed images
+export interface ProcessedImageEvent {
+  target: {
+    files: [string] // Array with exactly one string (the processed image URL)
+  }
+}
+
 export interface FormStepProps {
   formData: CalendarFormData;
   updateFormField: (field: keyof CalendarFormData, value: unknown) => void;
@@ -16,7 +23,7 @@ export interface FormStepProps {
 
 export interface Step2Props extends FormStepProps {
   childPhoto: string | null;
-  handlePhotoUpload: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handlePhotoUpload: (e: React.ChangeEvent<HTMLInputElement> | ProcessedImageEvent) => void;
   handleActivityToggle: (activity: Activity) => void;
   updateStickerQuantity: (activityId: string, quantity: number) => void;
   removeCustomActivity: (id: string) => void;


### PR DESCRIPTION
## Description
This PR fixes an issue where the original, uncompressed image was being saved for child photos instead of using the processed/optimized version.

### Changes Made
- Modified `handlePhotoUpload` in the parent component to accept both File objects and processed image URLs
- Updated the child photo upload handler to use the processed image from `useImageUpload` hook
- Ensures that the optimized version of uploaded images is used throughout the application

### Benefits
- Improved performance through image optimization
- Reduced storage needs
- Consistent image processing across the application

### Technical Details
- The parent's `handlePhotoUpload` function now accepts either:
  - A standard file input event with File objects
  - An object containing a processed image URL
- The child component processes the image first using the `useImageUpload` hook before passing it to the parent
- All image optimization settings (size, quality, etc.) are maintained through the `CHILD_PHOTO` preset

### Testing
Please verify:
- [ ] Child photo upload works correctly
- [ ] The uploaded photo appears properly in the preview
- [ ] The image quality is maintained while file size is reduced
- [ ] Multiple uploads of the same photo work as expected

### Additional Notes
This change maintains all existing functionality while ensuring better performance and resource usage.