### PR TITLE
Increase upload max size from 5MB to 20MB

### DIFF
--- a/src/components/create-form/AddSticker.tsx
+++ b/src/components/create-form/AddSticker.tsx
@@ -170,7 +170,7 @@ export default function AddSticker({
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
                 </svg>
                 <p className="text-zinc-300 font-medium">Cliquez pour choisir une image</p>
-                <p className="text-sm text-zinc-500 mt-1">JPG, PNG (max. 5 Mo)</p>
+                <p className="text-sm text-zinc-500 mt-1">JPG, PNG (max. 20 Mo)</p>
               </div>
               <input
                 type="file"

--- a/src/components/create-form/BackgroundUpload.tsx
+++ b/src/components/create-form/BackgroundUpload.tsx
@@ -74,7 +74,7 @@ export default function BackgroundUpload({
             <p className="mt-2 text-sm font-medium">
               {isUploading ? "Chargement..." : "Cliquez pour choisir une image"}
             </p>
-            <p className="mt-1 text-xs text-zinc-300">PNG, JPG, WebP (max. 5 Mo)</p>
+            <p className="mt-1 text-xs text-zinc-300">PNG, JPG, WebP (max. 20 Mo)</p>
           </div>
           <input type="file" className="hidden" accept="image/*" onChange={handleBackgroundUpload} />
         </label>

--- a/src/components/create-form/HeroImage.tsx
+++ b/src/components/create-form/HeroImage.tsx
@@ -86,7 +86,7 @@ export default function HeroImage({
             {childPhoto ? 'Changer la photo' : 'Ajouter une photo'}
           </div>
           <p className="text-xs text-zinc-500 mt-1">
-            JPG, PNG (max. 5 Mo)
+            JPG, PNG (max. 20 Mo)
           </p>
         </div>
         <input

--- a/src/lib/utils/image-processing.ts
+++ b/src/lib/utils/image-processing.ts
@@ -4,7 +4,7 @@
  */
 
 // Constants for image processing
-const MAX_IMAGE_SIZE_MB = 5
+const MAX_IMAGE_SIZE_MB = 20
 const MAX_IMAGE_SIZE_BYTES = MAX_IMAGE_SIZE_MB * 1024 * 1024
 
 // Presets for different image types
@@ -16,9 +16,9 @@ export const IMAGE_PRESETS = {
     name: 'background'
   },
   STICKER: {
-    maxWidth: 600,
-    maxHeight: 600,
-    quality: 0.85,
+    maxWidth: 800,
+    maxHeight: 800,
+    quality: 0.9,
     name: 'sticker'
   },
   CHILD_PHOTO: {


### PR DESCRIPTION
This PR addresses issue #10 by increasing the maximum upload file size from 5MB to 20MB.

## Changes:
- Increased MAX_IMAGE_SIZE_MB constant from 5 to 20 in image-processing.ts
- Updated the IMAGE_PRESETS to set the same settings for STICKER and CHILD_PHOTO (800x800, 0.9 quality)
- Updated all UI text instances that mentioned the 5MB limit to display 20MB instead
- The file size validation in validateImage() now allows images up to 20MB

Since the images are processed (resized and compressed) before being stored in localStorage, this change will allow users to upload much larger original images without issues.